### PR TITLE
Initial commit for output plugin for mdm-statsd

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/fluent-plugin-mdm.gemspec
+++ b/fluent-plugin-mdm.gemspec
@@ -1,0 +1,28 @@
+lib = File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+Gem::Specification.new do |spec|
+  spec.name    = "fluent-plugin-mdm"
+  spec.version = "0.1.0"
+  spec.authors = ["Jorge Villaseñor"]
+  spec.email   = ["jovillas@microsoft.com"]
+
+  spec.description   = "An output plugin to send metrics to MDM using the statsd interface"
+  spec.summary       = spec.description
+  spec.name          = "fluent-plugin-mdm"
+  spec.homepage      = "https://github.com/Azure/fluent-plugin-mdm"
+  spec.license       = "MIT"
+
+  test_files, files  = `git ls-files -z`.split("\x0").partition do |f|
+    f.match(%r{^(test|spec|features)/})
+  end
+  spec.files         = `git ls-files`.split("\n")
+  spec.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  spec.test_files    = test_files
+  spec.require_paths = ["lib"]
+
+  spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "rake", "~> 12.0"
+  spec.add_development_dependency "test-unit", "~> 3.0"
+  spec.add_runtime_dependency "fluentd", [">= 0.14.10", "< 2"]
+end

--- a/fluent-plugin-mdm.gemspec
+++ b/fluent-plugin-mdm.gemspec
@@ -4,8 +4,8 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 Gem::Specification.new do |spec|
   spec.name    = "fluent-plugin-mdm"
   spec.version = "0.1.0"
-  spec.authors = ["Jorge Villaseñor"]
-  spec.email   = ["jovillas@microsoft.com"]
+  spec.authors = ["HANA RP Devs"]
+  spec.email   = ["hanarpdevs@microsoft.com"]
 
   spec.description   = "An output plugin to send metrics to MDM using the statsd interface"
   spec.summary       = spec.description

--- a/lib/fluent/plugin/out_mdm.rb
+++ b/lib/fluent/plugin/out_mdm.rb
@@ -58,9 +58,9 @@ module Fluent
         begin
           @socket.send(metric, 0, @host, @port)
         rescue Errno::ECONNREFUSED => error
-          log.warn "Error connecting to #{@host}: #{error}"
+          log.warn "Error connecting to #{@host} while sending the record \"#{record}\": #{error}"
         rescue => error
-          log.error "Unhandled error trying to send MDM message"
+          log.error "Unhandled error trying to send MDM message: \"#{record}\""
         end
       }
     end

--- a/lib/fluent/plugin/out_mdm.rb
+++ b/lib/fluent/plugin/out_mdm.rb
@@ -1,0 +1,69 @@
+require 'fluent/output'
+require 'json'
+
+module Fluent
+  class MDMOutput < Output
+    # First, register the plugin. NAME is the name of this plugin
+    # and identifies the plugin in the configuration file.
+    Fluent::Plugin.register_output('mdm', self)
+
+    # config_param defines a parameter. You can refer a parameter via @path instance variable
+    # Without :default, a parameter is required.
+    config_param :host, :string, :default => "0.0.0.0"
+    config_param :port, :integer, :default => 8125
+
+    # This method is called before starting.
+    # 'conf' is a Hash that includes configuration parameters.
+    # If the configuration is invalid, raise Fluent::ConfigError.
+    def configure(conf)
+      super
+
+      # You can also refer raw parameter via conf[name].
+      @conf = conf
+    end
+
+    # This method is called when starting.
+    # Open sockets or files here.
+    def start
+      super
+      @socket = UDPSocket.new(Socket::AF_INET)
+    end
+
+    # This method is called when shutting down.
+    # Shutdown the thread and close sockets or files here.
+    def shutdown
+      super
+    end
+
+    # This method is called when an event reaches Fluentd.
+    # 'es' is a Fluent::EventStream object that includes multiple events.
+    # You can use 'es.each {|time,record| ... }' to retrieve events.
+    # 'chain' is an object that manages transactions. Call 'chain.next' at
+    # appropriate points and rollback if it raises an exception.
+    #
+    # NOTE! This method is called by Fluentd's main thread so you should not write slow routine here. It causes Fluentd's performance degression.
+    def emit(tag, es, chain)
+      chain.next
+      es.each {|time,record|
+        value = record["Value"]
+
+        stat = {
+          "Namespace"=> record["Namespace"],
+          "Metric"=> record["Metric"],
+          "Dims"=> record["Dimensions"]
+        }
+
+        metric = "#{stat.to_json}:#{value}|g"
+
+        begin
+          @socket.send(metric, 0, @host, @port)
+        rescue Errno::ECONNREFUSED => error
+          log.warn "Error connecting to #{@host}: #{error}"
+        rescue => error
+          log.error "Unhandled error trying to send MDM message"
+        end
+      }
+    end
+
+  end
+end


### PR DESCRIPTION
The current plugin takes a record from fluentd with the required
information to send an MDM metric. The record is processed and a json
string is build to add the metrics namespace, dimensions and metric name
to be used by Geneva. Then it's sent via UDP to the statsd front end for
MDM.